### PR TITLE
chore: add gitignore and document exclusions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Environment-specific files
+.env
+credentials.json
+
+# Dependencies
+node_modules/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+*.log
+
+# Operating system files
+.DS_Store
+
+# Editor directories and files
+.vscode/
+.idea/
+*.swp

--- a/README.md
+++ b/README.md
@@ -68,8 +68,17 @@ README.md        - This file
 ## 🔒 Security Notes
 
 * Never commit API keys, tokens, or passwords.
-* Keep `.env` files and local configuration out of version control.
 * Use n8n’s built-in credentials manager for sensitive information.
+
+### Environment-specific exclusions
+
+The repository's `.gitignore` prevents committing local files that should remain private, including:
+
+* `.env` – environment variables
+* `credentials.json` – service credentials
+* `node_modules/` – installed dependencies
+
+Add any other files specific to your setup to `.gitignore` to keep them out of version control.
 
 ---
 


### PR DESCRIPTION
## Summary
- add .gitignore to exclude local environment files and dependencies
- document environment-specific exclusions in README

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a39560cec0832b8bbf61d60f5cfc89