### PR TITLE
Use env variables and credentials for WordPress and OpenAI config

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,13 @@ When a church uploads its latest sermon, these workflows pull the sermon’s tit
 * API credentials for connected social media platforms
   *(Store securely in n8n’s credentials manager or a `.env` file — never commit credentials to the repository.)*
 
+### Environment Variables & Credentials
+
+| Name | Purpose | Where to set |
+| ---- | ------- | ------------ |
+| `WORDPRESS_BASE_URL` | Base URL of your WordPress site (without trailing slash). Used by HTTP Request nodes to pull sermon data. | Environment variable in n8n |
+| `OpenAi account` | OpenAI API key used for generating Facebook post content. | n8n credentials manager |
+
 ---
 
 ## 📂 Repository Structure

--- a/WordPress to FaceBook Posting.json
+++ b/WordPress to FaceBook Posting.json
@@ -20,7 +20,7 @@
     },
     {
       "parameters": {
-        "url": "http://lukashoyle2025.mystagingwebsite.com/wp-json/wp/v2/ctc_sermon?per_page=5&orderby=date&order=desc&_embed",
+        "url": "={{ $env.WORDPRESS_BASE_URL + '/wp-json/wp/v2/ctc_sermon?per_page=5&orderby=date&order=desc&_embed' }}",
         "options": {}
       },
       "type": "n8n-nodes-base.httpRequest",
@@ -34,7 +34,7 @@
     },
     {
       "parameters": {
-        "url": "=http://lukashoyle2025.mystagingwebsite.com/wp-json/wp/v2/ctc_sermon/{{ $json.id }}?_fields=id,link,title,rendered,content,rendered",
+        "url": "={{ $env.WORDPRESS_BASE_URL + '/wp-json/wp/v2/ctc_sermon/' + $json.id + '?_fields=id,link,title,rendered,content,rendered' }}",
         "options": {}
       },
       "type": "n8n-nodes-base.httpRequest",
@@ -85,10 +85,10 @@
       "id": "9821d108-5293-4718-b3f0-52fb89f33ffc",
       "name": "Generate Facebook post content",
       "credentials": {
-        "openAiApi": {
-          "id": "INSERT_YOURS_HERE",
-          "name": "OpenAi account"
-        }
+          "openAiApi": {
+            "id": "={{ $credentials.openAiApi.id }}",
+            "name": "OpenAi account"
+          }
       }
     },
     {


### PR DESCRIPTION
## Summary
- pull WordPress HTTP request URLs from a `WORDPRESS_BASE_URL` environment variable
- reference the OpenAI API key via n8n credentials instead of a placeholder
- document required environment variable and credential setup

## Testing
- `jq . 'WordPress to FaceBook Posting.json'`
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a3956c4860832b875e7991f52255d7